### PR TITLE
MNIST/FedProx implementation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,22 @@ pip install flwr["simulation"]
 python main.py
 ```
 
+## MNIST FedProx
+
+### 1. Install dependencies
+
+First of all **activate the virtual environment**. Then run the following command:
+
+```bash
+pip install -r requirements.txt
+```
+
+### 2. Run the main script
+
+```bash
+python main.py num_epochs=5 num_rounds=1000 iid=True
+```
+
 # Credits
 
 - Used the [MNIST dataset](https://www.tensorflow.org/datasets/catalog/mnist) from TensorFlow Datasets

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ First of all **activate the virtual environment**. Then run the following comman
 
 ```bash
 pip install -r requirements.txt
+pip install -U flwr["simulation"]
+
 ```
 
 ### 2. Run the main script

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A repo to show the visual comparison between different federated learning algori
 <summary>Click to expand</summary>
 
 - [x] FedAvg
-- [ ] FedProx
+- [x] FedProx
 - [ ] PerFedAvg
 - [ ] QFed
 </details>

--- a/mnist/fedprox/README.md
+++ b/mnist/fedprox/README.md
@@ -1,18 +1,10 @@
 # FedProx MNIST
 
-The following baseline replicates the experiments in *Federated Optimization in Heterogeneous Networks* (Li et al., 2018), which proposed the FedProx algorthim.
+The following baseline replicates the experiments in _Federated Optimization in Heterogeneous Networks_ (Li et al., 2018), which proposed the FedProx algorthim.
 
-**Paper Abstract:** 
-
-<center>
-<i>Federated Learning is a distributed learning paradigm with two key challenges that differentiate it from traditional distributed optimization: (1) significant variability in terms of the systems characteristics on each device in the network (systems heterogeneity), and (2) non-identically distributed data across the network (statistical heterogeneity). In this work, we introduce a framework, FedProx, to tackle heterogeneity in federated networks. FedProx can be viewed as a generalization and re-parametrization of FedAvg, the current state-of-the-art method for federated learning. While this re-parameterization makes only minor modifications to the method itself, these modifications have important ramifications both in theory and in practice. Theoretically, we provide convergence guarantees for our framework when learning over data from non-identical distributions (statistical heterogeneity), and while adhering to device-level systems constraints by allowing each participating device to perform a variable amount of work (systems heterogeneity). Practically, we demonstrate that FedProx allows for more robust convergence than FedAvg across a suite of realistic federated datasets. In particular, in highly heterogeneous settings, FedProx demonstrates significantly more stable and accurate convergence behavior relative to FedAvg---improving absolute test accuracy by 22% on average.</i>
-</center>
-
-**Paper Authors:** 
+**Paper Authors:**
 
 Tian Li, Anit Kumar Sahu, Manzil Zaheer, Maziar Sanjabi, Ameet Talwalkar and Virginia Smith.
-
-Note: If you use this implementation in your work, please remember to cite the original authors of the paper. 
 
 **[Link to paper.](https://arxiv.org/abs/1812.06127)**
 
@@ -22,32 +14,32 @@ Note: If you use this implementation in your work, please remember to cite the o
 
 The CNN architecture is detailed in the paper and used to create the **FedProx MNIST** baseline.
 
-| Layer | Details|
-| ----- | ------ |
-| 1 | Conv2D(1, 32, 5, 1, 1) <br/> ReLU, MaxPool2D(2, 2, 1)  |
-| 2 | Conv2D(32, 64, 5, 1, 1) <br/> ReLU, MaxPool2D(2, 2, 1) |
-| 3 | FC(64 * 7 * 7, 512) <br/> ReLU |
-| 5 | FC(512, 10) |
+| Layer | Details                                                |
+| ----- | ------------------------------------------------------ |
+| 1     | Conv2D(1, 32, 5, 1, 1) <br/> ReLU, MaxPool2D(2, 2, 1)  |
+| 2     | Conv2D(32, 64, 5, 1, 1) <br/> ReLU, MaxPool2D(2, 2, 1) |
+| 3     | FC(64 _ 7 _ 7, 512) <br/> ReLU                         |
+| 5     | FC(512, 10)                                            |
 
 ### Training Paramaters
 
-| Description | Value |
-| ----------- | ----- |
-| loss | cross entropy loss |
-| optimizer | SGD with proximal term |
-| learning rate | 0.03 (by default) |
-| local epochs | 5 (by default) |
-| local batch size | 10 (by default) |
+| Description      | Value                  |
+| ---------------- | ---------------------- |
+| loss             | cross entropy loss     |
+| optimizer        | SGD with proximal term |
+| learning rate    | 0.03 (by default)      |
+| local epochs     | 5 (by default)         |
+| local batch size | 10 (by default)        |
 
 ## Running experiments
 
 The `config.yaml` file containing all the tunable hyperparameters and the necessary variables can be found under the `conf` folder.
-[Hydra](https://hydra.cc/docs/tutorials/) is used to manage the different parameters experiments can be ran with. 
+[Hydra](https://hydra.cc/docs/tutorials/) is used to manage the different parameters experiments can be ran with.
 
-To run using the default parameters, just enter `python main.py`, if some parameters need to be overwritten, you can do it like in the following example: 
+To run using the default parameters, just enter `python main.py`, if some parameters need to be overwritten, you can do it like in the following example:
 
 ```sh
 python main.py num_epochs=5 num_rounds=1000 iid=True
-``` 
+```
 
-Results will be stored as timestamped folders inside either `outputs` or `multiruns`, depending on whether you perform single- or multi-runs. 
+Results will be stored as timestamped folders inside either `outputs` or `multiruns`, depending on whether you perform single- or multi-runs.

--- a/mnist/fedprox/client.py
+++ b/mnist/fedprox/client.py
@@ -10,8 +10,8 @@ import torch
 from flwr.common.typing import NDArrays, Scalar
 from torch.utils.data import DataLoader
 
-from flwr_baselines.publications.fedprox_mnist import model
-from flwr_baselines.publications.fedprox_mnist.dataset import load_datasets
+import model
+from dataset import load_datasets
 
 
 class FlowerClient(

--- a/mnist/fedprox/main.py
+++ b/mnist/fedprox/main.py
@@ -9,7 +9,7 @@ import numpy as np
 import torch
 from omegaconf import DictConfig
 
-from flwr_baselines.publications.fedprox_mnist import client, utils
+import client, utils
 
 DEVICE: str = torch.device("cpu")
 

--- a/mnist/fedprox/requirements.txt
+++ b/mnist/fedprox/requirements.txt
@@ -1,2 +1,31 @@
 hydra-core==1.3
+##### Flower Baseline Dependencies
+# Under Apache-2.0 license
+# Authors: The Flower Authors <hello@flower.dev>
+# Website: https://flower.dev
+# Repository: https://github.com/adap/flower
+# Documentation: https://flower.dev
+
+##### dependencies
 flwr >= 0.18.0
+numpy >= 1.20.0
+tqdm == 4.62.3
+matplotlib >= 3.5.0
+scikit-image >= 0.18.1
+scikit-learn >= 0.24.2
+wget >= 3.2
+
+##### dev-dependencies
+isort == 5.11.5
+black == 23.1.0
+docformatter == 1.5.1
+mypy == 0.961
+pylint == 2.8.2
+flake8 == 3.9.2
+pytest == 6.2.4
+pytest-watch == 4.2.0
+types-requests == 2.27.7
+
+
+torch
+torchvision

--- a/mnist/fedprox/requirements.txt
+++ b/mnist/fedprox/requirements.txt
@@ -1,0 +1,2 @@
+hydra-core==1.3
+flwr >= 0.18.0

--- a/mnist/fedprox/utils.py
+++ b/mnist/fedprox/utils.py
@@ -13,7 +13,7 @@ from flwr.common.typing import NDArrays, Scalar
 from flwr.server.history import History
 from torch.utils.data import DataLoader
 
-from flwr_baselines.publications.fedprox_mnist import model
+import model
 
 
 def plot_metric_from_history(


### PR DESCRIPTION
The PR adds the fedprox algo implemention on the mnist dataset. 

- Added the fedprox algo
- Updated the doc for fedprox
- Created a `requirements.txt` file for easy re-implementation/execution

